### PR TITLE
Single-bucket using S3 apis

### DIFF
--- a/src/storage/object.js
+++ b/src/storage/object.js
@@ -5,9 +5,9 @@ import {
 
 import getS3Config from './utils';
 
-function buildInput({ org, key, ext }) {
-  const Bucket = `${org}-content`;
-  return { Bucket, Key: key };
+function buildInput({ bucket, org, key, ext }) {
+  const Bucket = bucket;
+  return { Bucket, Key: `${org}/${key}` };
 }
 
 export default async function getObject(env, daCtx) {

--- a/src/utils/daCtx.js
+++ b/src/utils/daCtx.js
@@ -20,9 +20,10 @@ export function getDaCtx(pathname) {
 
   // Get base details
   const [org, ...parts] = sanitized.split('/');
+  const bucket = env.DA_BUCKET;
 
   // Set base details
-  const daCtx = { org };
+  const daCtx = { bucket, org };
 
   // Sanitize the remaining path parts
   const path = parts.filter((part) => part !== '');
@@ -35,7 +36,7 @@ export function getDaCtx(pathname) {
 
   // Handle folders and files under a site
   const split = daCtx.filename.split('.');
-  
+
   // DA Content - Add HTML if there is only one part to the split
   if (split.length === 1) split.push('html');
   daCtx.isFile = split.length > 1;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,5 @@
 name = "da-content"
 main = "src/index.js"
 compatibility_date = "2023-11-21"
+
+vars = { DA_BUCKET = "da-content" }


### PR DESCRIPTION
## Description

Implement storage using a single bucket using S3 APIs.

The bucket is normally called da-content but the name can be overridden in the wrangler.toml file.

## Related Issue

https://github.com/adobe/da-admin/issues/113

## How Has This Been Tested?

Testing is in progress.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
