### PR TITLE
fix: Configurations from .helix return 404

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ export default {
 
     if (pathname === '/favicon.ico') return get404();
     if (pathname === '/robots.txt') return getRobots();
-    if ([...pathname].filter((c) => c === '.').length > 1) return get404(); 
 
     const [, org, site] = url.pathname.split('/');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The newly added check that maximum `.` is allowed (the one for extension) is not correct, because there are cases like configs in `.helix` which can add an additional `..

## Related Issue

#3 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually in stage

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
