### PR TITLE
fix: sanitize JWT cookie value to prevent injection

### DIFF
--- a/src/cookie.js
+++ b/src/cookie.js
@@ -62,7 +62,7 @@ export function getCookie(req, org, site) {
 
   const authToken = headers.get('Authorization');
   if (authToken) {
-    const cookieValue = authToken.split(' ')[1];
+    const cookieValue = authToken.split(' ')[1]?.replace(/[^a-zA-Z0-9\-_.=]/g, '') || null;
 
     if (cookieValue) {
       const respHeaders = new Headers();


### PR DESCRIPTION
Fixes a cookie injection vulnerability where the auth_token cookie value was set directly from the Authorization header without sanitization. An attacker could inject arbitrary cookie attributes (e.g., ; Domain=.evil.com) via a crafted header. The fix sanitizes the value to only allow valid JWT characters (base64url + dot separator).