### PR TITLE
fix: Switch from an opt-in config to an opt-out config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,13 +37,12 @@ function shouldGetFromStorage(env, req, pathname, org) {
     return true;
   }
 
-  // Embeddable assets go to storage by default
+  // Embeddable assets (images) go to admin by default unless org opts out
   if (isEmbeddableAsset(pathname)) {
-    // Admin opt-in orgs use admin even for embeddable assets
-    if (env.ADMIN_OPTIN_ORGS?.split(',').includes(org)) {
-      return false;
+    if (env.ADMIN_IMAGES_OPTOUT_ORGS?.split(',').includes(org)) {
+      return true;
     }
-    return true;
+    return false;
   }
 
   return false;

--- a/src/storage/admin.js
+++ b/src/storage/admin.js
@@ -101,10 +101,11 @@ export default async function getFromAdmin(req, env) {
     });
     const { status, headers } = resp;
     const body = await resp.blob();
+    const contentType = headers.get('content-type');
 
     // eslint-disable-next-line no-console
     console.log('<- admin responded with:', status);
-    return new Response(body, { status, headers });
+    return daResp({ body, status, contentType });
   } catch (e) {
     const msg = 'Failed to fetch from admin';
     // eslint-disable-next-line no-console

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -179,10 +179,10 @@ describe('Index Tests', () => {
     });
   });
 
-  describe('embeddable assets (storage by default)', () => {
-    it('uses storage for .png when not allowlisted', async () => {
-      nock.s3(S3_BUCKET_HOST)
-        .get(/\/.+/)
+  describe('embeddable assets (admin by default)', () => {
+    it('uses admin for .png when not opted out', async () => {
+      nock.admin()
+        .get(/\/source\/.+/)
         .reply(200, 'fake-png-bytes', { 'content-type': 'image/png' });
 
       const req = createRequest('https://example.com/some-org/site/logo.png', {
@@ -196,25 +196,25 @@ describe('Index Tests', () => {
       expect(await result.text()).to.equal('fake-png-bytes');
     });
 
-    it('uses admin for embeddable asset when org is in ADMIN_OPTIN_ORGS', async () => {
-      nock.admin()
-        .get(/\/source\/.+/)
-        .reply(200, 'admin content', { 'content-type': 'text/html' });
+    it('uses storage for embeddable asset when org is in ADMIN_IMAGES_OPTOUT_ORGS', async () => {
+      nock.s3(S3_BUCKET_HOST)
+        .get(/\/.+/)
+        .reply(200, 'storage content', { 'content-type': 'image/png' });
 
-      const req = createRequest('https://example.com/optin-org/site/logo.png', {
+      const req = createRequest('https://example.com/optout-org/site/logo.png', {
         headers: { 'cf-connecting-ip': '1.2.3.4' },
       });
-      const env = createEnv({ ADMIN_OPTIN_ORGS: 'optin-org' });
+      const env = createEnv({ ADMIN_IMAGES_OPTOUT_ORGS: 'optout-org' });
 
       const result = await worker.fetch(req, env);
 
       expect(result.status).to.equal(200);
-      expect(await result.text()).to.equal('admin content');
+      expect(await result.text()).to.equal('storage content');
     });
 
-    it('uses storage for .svg and sets Content-Disposition attachment', async () => {
-      nock.s3(S3_BUCKET_HOST)
-        .get(/\/.+/)
+    it('uses admin for .svg and sets Content-Disposition attachment', async () => {
+      nock.admin()
+        .get(/\/source\/.+/)
         .reply(200, '<svg/>', { 'content-type': 'image/svg+xml' });
 
       const req = createRequest('https://example.com/some-org/site/icon.svg', {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

All customer, aside from those opted out will have their images requiring auth in the form of `authorization` header or the cookie.
This should work in the DA editor and LivePreview proxy but customers with images from cross DA sites or cross DA orgs might be affected.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
