### PR TITLE
fix: stream upstream body in getFromAdmin to prevent OOM

### DIFF
--- a/src/storage/admin.js
+++ b/src/storage/admin.js
@@ -100,9 +100,10 @@ export default async function getFromAdmin(req, env) {
       headers: reqHeaders,
     });
 
+    const { status, headers } = resp;
     // eslint-disable-next-line no-console
-    console.log('<- admin responded with:', resp.status);
-    return new Response(resp.body, { status: resp.status, headers: resp.headers });
+    console.log('<- admin responded with:', status);
+    return new Response(resp.body, { status, headers });
   } catch (e) {
     const msg = 'Failed to fetch from admin';
     // eslint-disable-next-line no-console

--- a/src/storage/admin.js
+++ b/src/storage/admin.js
@@ -99,12 +99,10 @@ export default async function getFromAdmin(req, env) {
     const resp = await env.daadmin.fetch(url, {
       headers: reqHeaders,
     });
-    const { status, headers } = resp;
-    const body = await resp.blob();
 
     // eslint-disable-next-line no-console
-    console.log('<- admin responded with:', status);
-    return new Response(body, { status, headers });
+    console.log('<- admin responded with:', resp.status);
+    return new Response(resp.body, { status: resp.status, headers: resp.headers });
   } catch (e) {
     const msg = 'Failed to fetch from admin';
     // eslint-disable-next-line no-console

--- a/test/storage/admin.test.js
+++ b/test/storage/admin.test.js
@@ -223,4 +223,38 @@ describe('getFromAdmin', () => {
       expect(result.headers.get('x-error')).to.equal('Failed to fetch from admin');
     });
   });
+
+  describe('response body streaming', () => {
+    it('forwards the upstream body without fully buffering it in memory', async () => {
+      const upstreamBody = new TextEncoder().encode('image-bytes');
+      const upstream = new Response(upstreamBody, {
+        status: 200,
+        headers: { 'content-type': 'image/jpeg' },
+      });
+      const fullBufferReads = [];
+      const proxied = new Proxy(upstream, {
+        get(target, prop) {
+          if (prop === 'blob' || prop === 'arrayBuffer' || prop === 'text') {
+            return async () => {
+              fullBufferReads.push(prop);
+              return target[prop]();
+            };
+          }
+          const value = target[prop];
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+
+      const req = createRequest('https://example.com/org/site/photo.jpg');
+      const env = { daadmin: { fetch: async () => proxied } };
+
+      const result = await getFromAdmin(req, env);
+
+      expect(fullBufferReads, 'worker must not read the upstream body into memory before responding').to.deep.equal([]);
+      expect(result.status).to.equal(200);
+      expect(result.headers.get('content-type')).to.equal('image/jpeg');
+      const out = new Uint8Array(await result.arrayBuffer());
+      expect(out).to.deep.equal(upstreamBody);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`da-content` Worker isolates have been hitting the 128 MB memory ceiling when serving large assets routed through `getFromAdmin`. Root cause: `src/storage/admin.js` calls `await resp.blob()` on the upstream response from `da-admin`, fully buffering the body into the isolate before forwarding it to the client. Under bursty traffic the buffered blobs accumulate and the runtime kills the request with `Error: Worker exceeded memory limit.`.

The fix is the canonical Workers proxy pattern: stream `resp.body` directly into the new `Response` so the body flows from upstream to the client without ever fully materializing in the isolate.

## Failing-log signature

```
Exception: Error: Worker exceeded memory limit.
ScriptName: da-content
Logs[0].Message: ["-> get from admin", "https://admin.da.live/source/<org>/<site>/<path>/<image>.jpg"]
```

Concentrated on `.jpg` assets served via the admin opt-in path (`ADMIN_OPTIN_ORGS`, #17).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 78 passing (was 77 + 1 new streaming test)
- [x] New failing-first test in `test/storage/admin.test.js` asserts the worker does **not** call `.blob()` / `.arrayBuffer()` / `.text()` on the upstream Response (fails on `main`, passes with this patch)
- [ ] Post-deploy: 24h Coralogix sweep — `Worker exceeded memory limit.` events on da-content drop to 0 / single digits

## Notes

- Independent of #27 (opt-in → opt-out routing). #27 reduces the surface for new orgs; this PR fixes the buffering for opt-in orgs that remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)