### PR TITLE
feat: reduce logs noise

### DIFF
--- a/src/storage/admin.js
+++ b/src/storage/admin.js
@@ -94,20 +94,14 @@ export default async function getFromAdmin(req, env) {
   }
 
   try {
-    // eslint-disable-next-line no-console
-    console.log('-> get from admin', url);
     const resp = await env.daadmin.fetch(url, {
       headers: reqHeaders,
     });
     const { status, headers } = resp;
     const contentType = headers.get('content-type');
-    // eslint-disable-next-line no-console
-    console.log('<- admin responded with:', status);
     return daResp({ body: resp.body, status, contentType });
   } catch (e) {
     const msg = 'Failed to fetch from admin';
-    // eslint-disable-next-line no-console
-    console.error(msg, e);
     return new Response(
       '',
       {


### PR DESCRIPTION
3M requests per week that gives us a status code (and we have admin access logs). 2 log entries per requests for duplicate information...
In case of error, admin AND content have the x-error header... 

No need for these logs.